### PR TITLE
Fix: close town/industry list windows on landscape generation

### DIFF
--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -1078,7 +1078,9 @@ namespace OpenLoco::World::MapGenerator
         Input::processMessagesMini();
 
         WindowManager::close(WindowType::town);
+        WindowManager::close(WindowType::townList);
         WindowManager::close(WindowType::industry);
+        WindowManager::close(WindowType::industryList);
         Ui::ProgressBar::begin(StringIds::generating_landscape);
 
         auto rotation = WindowManager::getCurrentRotation();


### PR DESCRIPTION
## Summary
- Close townList and industryList windows in MapGenerator::generate() alongside existing town and industry window closes
- Prevents stale list data from persisting after landscape regeneration

## Details
When generating a new landscape, the individual town and industry detail windows were already being closed, but the list windows (WindowType::townList, WindowType::industryList) were not. This left stale entries visible in the list windows after regeneration.

Potential fix for:
https://github.com/knoxio/OpenLoco/issues/891

## Test plan
- [ ] Open the town list window, then generate a new landscape — verify the list window closes and does not show stale towns
- [ ] Open the industry list window, then generate a new landscape — verify the list window closes and does not show stale industries
- [ ] Verify normal landscape generation still works correctly