### PR TITLE
Fix crash when deleting town while Build Buildings tool is active

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -641,6 +641,15 @@ namespace OpenLoco::Ui::Windows::TownList
             return;
         }
 
+        // Only update rowInfo when on the town list tab. On other tabs (BuildBuildings,
+        // BuildMiscBuildings) rowInfo contains building object IDs, not town IDs.
+        // Blindly comparing against the town ID would corrupt building entries that
+        // happen to share the same numeric value, leading to a crash.
+        if (window->currentTab != Common::widx::tab_town_list - Common::widx::tab_town_list)
+        {
+            return;
+        }
+
         for (auto i = 0; i < window->var_83C; i++)
         {
             if (window->rowInfo[i] == enumValue(townId))


### PR DESCRIPTION
## Summary
- Guard the town-deleted event handler in TownList window to only update rowInfo on the town list tab
- On BuildBuildings/BuildMiscBuildings tabs, rowInfo contains building object IDs, not town IDs — the handler was corrupting entries that shared the same numeric value as the deleted town, causing a crash

Upstream issue: https://github.com/knoxio/OpenLoco/issues/892

## Test plan
- [ ] Open scenario editor, generate landscape with towns
- [ ] Open town list, switch to Build Individual Town Buildings tab
- [ ] Delete a town via the town window — should not crash
- [ ] Verify town list tab still updates correctly when a town is deleted