### PR TITLE
Fix crash when deselecting last built track/road type

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -1650,6 +1650,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             Gfx::loadDefaultPalette();
             Gfx::invalidateScreen();
             CompanyManager::determineAvailableVehicles();
+            CompanyManager::updatePlayerInfrastructureOptions();
             WindowManager::invalidate(WindowType::buildVehicle);
 
             // Stop being modal and unpause game.

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -827,11 +827,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             {
                 ebx = ebx & ~(1 << 7);
                 auto obj = ObjectManager::get<RoadObject>(ebx);
+                if (obj == nullptr)
+                {
+                    return;
+                }
                 fg_image = Gfx::recolour(obj->image, companyColour);
             }
             else
             {
                 auto obj = ObjectManager::get<TrackObject>(ebx);
+                if (obj == nullptr)
+                {
+                    return;
+                }
                 fg_image = Gfx::recolour(obj->image + TrackObj::ImageIds::kUiPreviewImage0, companyColour);
             }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -66,11 +66,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
             if (isRoad)
             {
                 auto obj = ObjectManager::get<RoadObject>(lastRoadOption & ~(1 << 7));
+                if (obj == nullptr)
+                {
+                    return;
+                }
                 fgImage = Gfx::recolour(obj->image, companyColour);
             }
             else
             {
                 auto obj = ObjectManager::get<TrackObject>(lastRoadOption);
+                if (obj == nullptr)
+                {
+                    return;
+                }
                 fgImage = Gfx::recolour(obj->image + TrackObj::ImageIds::kUiPreviewImage0, companyColour);
             }
 


### PR DESCRIPTION
## Summary
- Add null checks for TrackObject/RoadObject lookups in toolbar rendering code (ToolbarTop.cpp, ToolbarTopCommon.cpp)
- Call `CompanyManager::updatePlayerInfrastructureOptions()` after object selection changes to keep the available track/road options in sync

When deselecting a track type that was the last built type, the toolbar tried to render its icon via a now-invalid object pointer, causing a crash.

Upstream issue: https://github.com/OpenLoco/OpenLoco/issues/3034

## Test plan
- [ ] Start a game, build some track
- [ ] Open object selection, deselect the track type you just built
- [ ] Verify no crash and toolbar updates correctly
- [ ] Repeat with road objects