### PR TITLE
Fix OrderManager crash on corrupt/invalid order types

### DIFF
--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -651,6 +651,7 @@ namespace OpenLoco::S5
 
             Audio::stopVehicleNoise();
             EntityManager::resetSpatialIndex();
+            Vehicles::OrderManager::fixCorruptWaypointOrders();
             CompanyManager::updateColours();
             ObjectManager::updateTerraformObjects();
             TileManager::resetSurfaceClearance();

--- a/src/OpenLoco/src/Vehicles/OrderManager.cpp
+++ b/src/OpenLoco/src/Vehicles/OrderManager.cpp
@@ -70,7 +70,9 @@ namespace OpenLoco::Vehicles
     {
         if (enumValue(_currentOrder->getType()) >= std::size(kOrderSizes))
         {
-            throw Exception::RuntimeError("Invalid order type!");
+            Logging::warn("OrderRingView: encountered corrupt order with invalid type {}. Stopping iteration.", enumValue(_currentOrder->getType()));
+            _hasLooped = true;
+            return *this;
         }
         if (_currentOrder->getType() == OrderType::End && _currentOrder == _beginOrderTable)
         {
@@ -80,7 +82,13 @@ namespace OpenLoco::Vehicles
         }
         auto* newOrders = reinterpret_cast<uint8_t*>(_currentOrder) + kOrderSizes[static_cast<uint8_t>(_currentOrder->getType())];
         _currentOrder = reinterpret_cast<Order*>(newOrders);
-        if (_currentOrder->getType() == OrderType::End)
+        if (enumValue(_currentOrder->getType()) >= std::size(kOrderSizes))
+        {
+            Logging::warn("OrderRingView: next order has invalid type {}. Wrapping to table start.", enumValue(_currentOrder->getType()));
+            _currentOrder = _beginOrderTable;
+            _hasLooped = true;
+        }
+        else if (_currentOrder->getType() == OrderType::End)
         {
             _currentOrder = _beginOrderTable;
             _hasLooped = true;
@@ -516,7 +524,55 @@ namespace OpenLoco::Vehicles::OrderManager
                     }
                 }
             }
-            i += kOrderSizes[enumValue(order.getType())];
+            auto typeIndex = enumValue(order.getType());
+            if (typeIndex >= std::size(kOrderSizes))
+            {
+                Logging::warn("removeOrdersForStation: corrupt order at offset {} with invalid type {}. Skipping byte.", i, typeIndex);
+                i++;
+                continue;
+            }
+            i += kOrderSizes[typeIndex];
+        }
+    }
+
+    // Scan the global order table and remove any orders with invalid types.
+    // This handles save files that contain corrupted order data which would
+    // otherwise cause crashes in OrderRingView iteration.
+    void fixCorruptWaypointOrders()
+    {
+        for (auto* head : VehicleManager::VehicleList())
+        {
+            bool corrupted = false;
+            uint16_t offset = 0;
+            while (offset < head->sizeOfOrderTable)
+            {
+                auto& order = orders()[head->orderTableOffset + offset];
+                auto typeIndex = enumValue(order.getType());
+                if (typeIndex >= std::size(kOrderSizes))
+                {
+                    Logging::warn("fixCorruptWaypointOrders: vehicle at orderTableOffset {} has corrupt order at offset {} (type {}). Replacing with End marker.", head->orderTableOffset, offset, typeIndex);
+                    // Overwrite the corrupt byte with an End order to terminate the table
+                    order = OrderEnd{};
+                    // Shrink the order table to end here
+                    auto removedSize = head->sizeOfOrderTable - offset - kOrderSizes[enumValue(OrderType::End)];
+                    if (removedSize > 0)
+                    {
+                        head->sizeOfOrderTable = offset + kOrderSizes[enumValue(OrderType::End)];
+                    }
+                    corrupted = true;
+                    break;
+                }
+                if (order.getType() == OrderType::End)
+                {
+                    break;
+                }
+                offset += kOrderSizes[typeIndex];
+            }
+            if (corrupted)
+            {
+                // Reset current order to 0 to avoid pointing into removed data
+                head->currentOrder = 0;
+            }
         }
     }
 }

--- a/src/OpenLoco/src/Vehicles/OrderManager.cpp
+++ b/src/OpenLoco/src/Vehicles/OrderManager.cpp
@@ -466,7 +466,8 @@ namespace OpenLoco::Vehicles::OrderManager
             auto orderType = rawOrder & 0x7;
             if (orderType >= std::size(kOrderSizes))
             {
-                throw Exception::OutOfRange("Order type is greater than the order size table");
+                Logging::warn("reverseVehicleOrderTable: skipping corrupt order with type {}.", orderType);
+                continue;
             }
             auto orderLength = kOrderSizes[orderType];
             std::memcpy(dest, &rawOrder, orderLength);
@@ -551,13 +552,13 @@ namespace OpenLoco::Vehicles::OrderManager
                 if (typeIndex >= std::size(kOrderSizes))
                 {
                     Logging::warn("fixCorruptWaypointOrders: vehicle at orderTableOffset {} has corrupt order at offset {} (type {}). Replacing with End marker.", head->orderTableOffset, offset, typeIndex);
-                    // Overwrite the corrupt byte with an End order to terminate the table
-                    order = OrderEnd{};
+                    // Zero the byte to create a clean End order (type 0 = End)
+                    order._type = 0;
                     // Shrink the order table to end here
-                    auto removedSize = head->sizeOfOrderTable - offset - kOrderSizes[enumValue(OrderType::End)];
-                    if (removedSize > 0)
+                    auto newSize = static_cast<uint16_t>(offset + kOrderSizes[enumValue(OrderType::End)]);
+                    if (newSize < head->sizeOfOrderTable)
                     {
-                        head->sizeOfOrderTable = offset + kOrderSizes[enumValue(OrderType::End)];
+                        head->sizeOfOrderTable = newSize;
                     }
                     corrupted = true;
                     break;

--- a/src/OpenLoco/src/Vehicles/OrderManager.h
+++ b/src/OpenLoco/src/Vehicles/OrderManager.h
@@ -27,8 +27,9 @@ namespace OpenLoco::Vehicles
                 : _beginOrderTable(beginOrderTable)
                 , _currentOrder(currentOrder)
             {
-                // Prevent empty tables looping
-                if (_currentOrder->getType() == OrderType::End)
+                // Prevent empty or corrupt tables from looping
+                if (_currentOrder->getType() == OrderType::End
+                    || static_cast<uint8_t>(_currentOrder->getType()) > static_cast<uint8_t>(OrderType::WaitFor))
                 {
                     _hasLooped = true;
                 }

--- a/src/OpenLoco/src/Vehicles/Orders.cpp
+++ b/src/OpenLoco/src/Vehicles/Orders.cpp
@@ -19,7 +19,12 @@ namespace OpenLoco::Vehicles
 
     bool Order::hasFlags(const OrderFlags flag) const
     {
-        return (kOrderFlags[static_cast<uint8_t>(getType())] & flag) != OrderFlags::none;
+        auto typeIndex = static_cast<uint8_t>(getType());
+        if (typeIndex >= std::size(kOrderFlags))
+        {
+            return false;
+        }
+        return (kOrderFlags[typeIndex] & flag) != OrderFlags::none;
     }
 
     template<typename T>


### PR DESCRIPTION
## Summary
- Replace crashing exception in OrderRingView iteration with graceful degradation (warn + stop iteration) when encountering corrupt order data
- Add bounds checking in Order::hasFlags and removeOrdersForStation to prevent out-of-bounds array access
- Add fixCorruptWaypointOrders() that runs at save-load time to detect and repair corrupt order entries

Potential fix for: https://github.com/knoxio/OpenLoco/issues/847
Potential fix for: https://github.com/knoxio/OpenLoco/issues/845
Potential fix for: https://github.com/knoxio/OpenLoco/issues/797

## Test plan
- Load a save file known to trigger 'Invalid order type!' crash — should now load without crashing
- Corrupt order entries should be logged as warnings and replaced with End markers
- Vehicles with repaired orders should continue functioning with their order list truncated at the corruption point
- Normal gameplay with valid orders should be completely unaffected
