### PR TITLE
Fix minimum land height lower bound (0 -> 1)

### DIFF
--- a/src/OpenLoco/src/Scenario/Scenario.h
+++ b/src/OpenLoco/src/Scenario/Scenario.h
@@ -82,7 +82,7 @@ namespace OpenLoco::Scenario
     constexpr uint8_t kMinRiverMeanderRate = 0;
     constexpr uint8_t kMaxRiverMeanderRate = 20;
 
-    constexpr uint8_t kMinBaseLandHeight = 0;
+    constexpr uint8_t kMinBaseLandHeight = 1;
     constexpr uint8_t kMaxBaseLandHeight = 15;
 
     constexpr uint8_t kMinHillDensity = 0;


### PR DESCRIPTION
## Summary
- Change `kMinBaseLandHeight` from 0 to 1 in `Scenario.h` to match original Locomotion behavior
- Setting min land height to 0 exposed the void beneath the map and caused rendering/gameplay issues when water level was higher

Upstream issue: https://github.com/knoxio/OpenLoco/issues/865

## Test plan
- [ ] Open scenario editor, go to Landscape Generation > Land tab
- [ ] Try to reduce minimum land height stepper below 1 — should stop at 1
- [ ] Generate landscape with min height 1 and higher water level — no void exposure