### PR TITLE
Fix loan value not displayed for non-player companies

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -1757,7 +1757,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self.widgets[Common::widx::company_select].left = self.width - 28;
 
             const auto isControllingCompany = company->id() == CompanyManager::getControllingId();
-            self.widgets[widx::currentLoan].hidden = !isControllingCompany;
             self.widgets[widx::loan_decrease].hidden = !isControllingCompany;
             self.widgets[widx::loan_increase].hidden = !isControllingCompany;
             self.widgets[widx::loan_autopay].hidden = !isControllingCompany;


### PR DESCRIPTION
## Summary
- Stop hiding the `currentLoan` widget for non-player companies — only hide the stepper buttons and autopay checkbox
- The loan value was invisible because the entire widget (including its formatted text) was hidden, while the `Current loan:` label was drawn separately

Upstream issue: https://github.com/knoxio/OpenLoco/issues/786

## Test plan
- [ ] Play a scenario with AI opponents
- [ ] Open an AI company's window, go to finances tab
- [ ] Verify the loan value is now displayed next to `Current loan:`
- [ ] Verify the +/- stepper buttons and autopay checkbox are still hidden for non-player companies
- [ ] Verify player's own finances window still works normally with steppers visible