### PR TITLE
Fix challenge timer overflow when deadline passes

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -2533,7 +2533,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             if ((Scenario::getObjective().flags & Scenario::ObjectiveFlags::withinTimeLimit) != Scenario::ObjectiveFlags::none)
             {
                 // time limited challenge
-                uint16_t monthsLeft = Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjectiveProgress().monthsInChallenge;
+                auto totalMonths = static_cast<uint16_t>(Scenario::getObjective().timeLimitYears) * 12;
+                auto elapsed = Scenario::getObjectiveProgress().monthsInChallenge;
+                uint16_t monthsLeft = elapsed >= totalMonths ? 0 : totalMonths - elapsed;
                 uint16_t years = monthsLeft / 12;
                 uint16_t months = monthsLeft % 12;
 

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -347,7 +347,9 @@ namespace OpenLoco::Ui::Windows::TimePanel
 
             if ((Scenario::getObjective().flags & Scenario::ObjectiveFlags::withinTimeLimit) != Scenario::ObjectiveFlags::none)
             {
-                uint16_t monthsLeft = (Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjectiveProgress().monthsInChallenge);
+                auto totalMonths = static_cast<uint16_t>(Scenario::getObjective().timeLimitYears) * 12;
+                auto elapsed = Scenario::getObjectiveProgress().monthsInChallenge;
+                uint16_t monthsLeft = elapsed >= totalMonths ? 0 : totalMonths - elapsed;
                 uint16_t yearsLeft = monthsLeft / 12;
                 monthsLeft = monthsLeft % 12;
                 args.push(StringIds::challenge_time_left);


### PR DESCRIPTION
## Summary
- Cast `timeLimitYears` (uint8_t) to uint16_t before multiplying by 12 to prevent arithmetic overflow
- Clamp remaining months to 0 when elapsed time exceeds the deadline, preventing unsigned underflow that displayed ~5459 years remaining
- Fixed in both display locations: TimePanel and CompanyWindow challenge tab

Upstream issue: https://github.com/knoxio/OpenLoco/issues/807

## Test plan
- [ ] Play a time-limited challenge scenario
- [ ] Let the deadline pass without completing the challenge
- [ ] Verify the timer shows 0 years 0 months remaining (not 5459 years)
- [ ] Verify timer displays correctly during normal gameplay before deadline