### PR TITLE
Fix music cycling when Mute is enabled

### DIFF
--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -1047,7 +1047,7 @@ namespace OpenLoco::Audio
     void playBackgroundMusic()
     {
         auto& cfg = Config::get();
-        if (cfg.audio.playJukeboxMusic == 0 || SceneManager::isTitleMode() || SceneManager::isEditorMode() || SceneManager::isPaused())
+        if (!_audioIsEnabled || cfg.audio.playJukeboxMusic == 0 || SceneManager::isTitleMode() || SceneManager::isEditorMode() || SceneManager::isPaused())
         {
             return;
         }


### PR DESCRIPTION
## Summary
- Add `_audioIsEnabled` check to `playBackgroundMusic()` to skip music selection when muted
- Previously, with Mute on and Play Music checked, the function called `Jukebox::changeTrack()` every frame, cycling through songs visually even though `playMusic()` bailed out due to its own mute check

Upstream issue: https://github.com/knoxio/OpenLoco/issues/789

## Test plan
- [ ] Enable both Mute and Play Music in audio settings
- [ ] Verify the "Currently playing" track no longer cycles rapidly
- [ ] Unmute — verify music resumes normally
- [ ] Verify muting during playback stops music