### PR TITLE
Fix loan going negative when holding repay button

### DIFF
--- a/src/OpenLoco/src/GameCommands/Company/ChangeLoan.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/ChangeLoan.cpp
@@ -12,15 +12,11 @@ namespace OpenLoco::GameCommands
     {
         GameCommands::setExpenditureType(ExpenditureType::LoanInterest);
 
-        if (newLoan < 0)
-        {
-            return FAILURE;
-        }
-
         auto* company = CompanyManager::get(GameCommands::getUpdatingCompanyId());
-        const currency32_t loanDifference = company->currentLoan - newLoan;
+        const auto clampedLoan = std::max<currency32_t>(newLoan, 0);
+        const currency32_t loanDifference = company->currentLoan - clampedLoan;
 
-        if (company->currentLoan > newLoan)
+        if (company->currentLoan > clampedLoan)
         {
             if (company->cash < loanDifference)
             {
@@ -31,7 +27,7 @@ namespace OpenLoco::GameCommands
         else
         {
             const auto maxLoan = Economy::getInflationAdjustedCost(CompanyManager::getMaxLoanSize(), 0, 8);
-            if (newLoan > maxLoan)
+            if (clampedLoan > maxLoan)
             {
                 GameCommands::setErrorText(StringIds::bank_refuses_to_increase_loan);
                 return FAILURE;
@@ -40,7 +36,7 @@ namespace OpenLoco::GameCommands
 
         if (flags & Flags::apply)
         {
-            company->currentLoan = newLoan;
+            company->currentLoan = clampedLoan;
             company->cash -= loanDifference;
             Ui::WindowManager::invalidate(Ui::WindowType::company, static_cast<uint16_t>(GameCommands::getUpdatingCompanyId()));
             if (CompanyManager::getControllingId() == GameCommands::getUpdatingCompanyId())


### PR DESCRIPTION
## Summary
- Clamp `newLoan` to zero in the `changeLoan` game command instead of allowing it to go negative
- Previously the loan would wrap to a negative value; now it repays down to exactly zero

Fixes https://github.com/knoxio/OpenLoco/issues/886

## Test plan
- [x] Open Finances window, take out a loan
- [x] Hold the repay button until loan reaches zero
- [x] Verify loan stops at exactly 0 and does not go negative
- [x] Verify small remaining amounts (e.g. less than the step size) are fully repaid
- [x] Verify normal loan increase/decrease still works correctly