### PR TITLE
Fix single-image newspaper not staying centered

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -329,24 +329,24 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 self.widgets[Common::widx::viewport1Button].hidden = false;
             }
 
+            self.widgets[Common::widx::viewport1].left = 6;
+            self.widgets[Common::widx::viewport1].right = 353;
+            self.widgets[Common::widx::viewport1Button].left = 4;
+            self.widgets[Common::widx::viewport1Button].right = 355;
+
+            if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
+            {
+                self.widgets[Common::widx::viewport1].left = 6;
+                self.widgets[Common::widx::viewport1].right = 173;
+                self.widgets[Common::widx::viewport1Button].left = 4;
+                self.widgets[Common::widx::viewport1Button].right = 175;
+            }
+
             if (_nState.savedView[0] != view)
             {
                 _nState.savedView[0] = view;
                 self.viewportRemove(0);
                 self.invalidate();
-
-                self.widgets[Common::widx::viewport1].left = 6;
-                self.widgets[Common::widx::viewport1].right = 353;
-                self.widgets[Common::widx::viewport1Button].left = 4;
-                self.widgets[Common::widx::viewport1Button].right = 355;
-
-                if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
-                {
-                    self.widgets[Common::widx::viewport1].left = 6;
-                    self.widgets[Common::widx::viewport1].right = 173;
-                    self.widgets[Common::widx::viewport1Button].left = 4;
-                    self.widgets[Common::widx::viewport1Button].right = 175;
-                }
 
                 if (!view.isEmpty())
                 {
@@ -424,16 +424,16 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 self.widgets[Common::widx::viewport2Button].hidden = false;
             }
 
+            self.widgets[Common::widx::viewport2].left = 186;
+            self.widgets[Common::widx::viewport2].right = 353;
+            self.widgets[Common::widx::viewport2Button].left = 184;
+            self.widgets[Common::widx::viewport2Button].right = 355;
+
             if (_nState.savedView[1] != view)
             {
                 _nState.savedView[1] = view;
                 self.viewportRemove(1);
                 self.invalidate();
-
-                self.widgets[Common::widx::viewport2].left = 186;
-                self.widgets[Common::widx::viewport2].right = 353;
-                self.widgets[Common::widx::viewport2Button].left = 184;
-                self.widgets[Common::widx::viewport2Button].right = 355;
 
                 if (!view.isEmpty())
                 {


### PR DESCRIPTION
## Summary
- Move viewport widget positioning code in `initViewport0` and `initViewport1` outside the `savedView != view` guard
- Previously, widget positions were only updated when the saved view changed, causing stale narrow layout from previous dual-image newspapers to persist when viewing consecutive single-image newspapers

Upstream issue: 3597

## Test plan
- [x] View a single-image newspaper (e.g. promotion)
- [x] View it again from message history — should remain centered
- [x] View a dual-image newspaper (e.g. citizens celebrate), then a single-image one — should be centered
- [x] Alternate between single and dual image newspapers — layout should always be correct