### PR TITLE
Fix crash when deselecting last built track/road type

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -1650,6 +1650,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             Gfx::loadDefaultPalette();
             Gfx::invalidateScreen();
             CompanyManager::determineAvailableVehicles();
+            CompanyManager::updatePlayerInfrastructureOptions();
             WindowManager::invalidate(WindowType::buildVehicle);
 
             // Stop being modal and unpause game.

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -827,11 +827,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             {
                 ebx = ebx & ~(1 << 7);
                 auto obj = ObjectManager::get<RoadObject>(ebx);
+                if (obj == nullptr)
+                {
+                    return;
+                }
                 fg_image = Gfx::recolour(obj->image, companyColour);
             }
             else
             {
                 auto obj = ObjectManager::get<TrackObject>(ebx);
+                if (obj == nullptr)
+                {
+                    return;
+                }
                 fg_image = Gfx::recolour(obj->image + TrackObj::ImageIds::kUiPreviewImage0, companyColour);
             }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -66,11 +66,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
             if (isRoad)
             {
                 auto obj = ObjectManager::get<RoadObject>(lastRoadOption & ~(1 << 7));
+                if (obj == nullptr)
+                {
+                    return;
+                }
                 fgImage = Gfx::recolour(obj->image, companyColour);
             }
             else
             {
                 auto obj = ObjectManager::get<TrackObject>(lastRoadOption);
+                if (obj == nullptr)
+                {
+                    return;
+                }
                 fgImage = Gfx::recolour(obj->image + TrackObj::ImageIds::kUiPreviewImage0, companyColour);
             }
 


### PR DESCRIPTION
Fixes #790

The toolbar remembers which track or road type you last built. When you open Object Selection and deselect one of those types, the object gets unloaded from memory — but the stored reference in the toolbar isn't cleared. So on the next redraw, it tries to look up an object that's no longer there, gets null, and crashes.

When the Object Selection window closes, we now call `updatePlayerInfrastructureOptions()` to revalidate what's still loaded and reset any stale last-built references. I also added null checks in the toolbar draw code as a safety net, since it should never be drawing with a null object anyway.

## Test plan
- [x] Start a game, build some track
- [x] Open object selection, deselect the track type you just built
- [x] Verify no crash and toolbar updates correctly
- [x] Repeat with road objects